### PR TITLE
Fixed circiut ID check for the digital inputs (unipi-input)

### DIFF
--- a/lib/unipi-input.js
+++ b/lib/unipi-input.js
@@ -19,6 +19,10 @@ module.exports = (RED) => {
         }
 
         input(device) {
+            if (this.config.circuit !== device.circuit) {
+                return
+            }
+
             this.updateStatus(device)
 
             if (!this.config.button) {
@@ -61,10 +65,6 @@ module.exports = (RED) => {
         }
 
         updateStatus(device) {
-            if (this.config.circuit !== device.circuit) {
-                return
-            }
-
             this.display(device.value)
         }
 


### PR DESCRIPTION
The unipi-input emits messages even if the message was not received from the selected circuit
(however the status is correctly was displayed). The circuit check is now moved to the beginning
of the input processing.
