### PR TITLE
Server connection closed on close event (eg: re-deploying flow) to avoid multiplicated flows

### DIFF
--- a/lib/unipi.js
+++ b/lib/unipi.js
@@ -21,6 +21,7 @@ module.exports = (RED) => {
             this.unipi
                 .on('connected', this.connected.bind(this))
                 .on('error', this.error.bind(this))
+                .on('close', this.close.bind(this))
                 .connect()
         }
 
@@ -46,6 +47,10 @@ module.exports = (RED) => {
                 shape: 'dot',
                 text: 'connected'
             })
+        }
+
+        close() {
+            this.unipi.close()
         }
     }
 


### PR DESCRIPTION
After a re-deploy the flow the messages are multiplicated by the unipi nodes as the server connection was not closed.
